### PR TITLE
rewrite console.log to console.warn to show that main field isn't used

### DIFF
--- a/packages/test1/webpack.config.js
+++ b/packages/test1/webpack.config.js
@@ -1,8 +1,15 @@
+const webpack = require('webpack');
+
 module.exports = {
   entry: './src/index.js',
   output: {
     filename: './dist/index.js',
     library: 'Test1',
     libraryTarget: 'umd',
-  }
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      "console.log": 'console.error'
+    })
+  ]
 };


### PR DESCRIPTION
Hey!

I've read https://github.com/ReactiveX/rxjs/issues/3227#issuecomment-365075058 and wanted to show you that webpack doesn't de-opt to using the `main` field, it continues to use the `module`, it's just that tree-shaking doesn't work because it'll de-optimize an esm build to a cjs build and cannot tree-shake it properly. (This might also maybe solvable if once webpack 4 lands and `"sideEffects": false` becomes more common in `package.json`)

That this PR does is just simply rewriting `console.log` to `console.error` in the dist folder, so UMD builds are always going to have `console.error`.

In any cases I've tried, webpack never went for the UMD build and always picked the ESM build.

